### PR TITLE
Add a line for converting an element into a container.

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
       <p>When drawing an element, hold <strong class="key osx">Option</strong> <strong class="key win">Alt</strong> to change the element's origin instead of its size.</p>
 
       <h2>Element Tool (R)</h2>
-      <p>The Element Tool is the most primitive of the drawing tools. It creates empty elements with no content. They can be useful for rapid prototyping or initial styling. However, it's recommended that these elements eventually be converted into containers.</p>
+      <p>The Element Tool is the most primitive of the drawing tools. It creates empty elements with no content. They can be useful for rapid prototyping or initial styling. However, it's recommended that these elements eventually be converted into containers.  You can convert a single empty element into a container directly using <strong class="key osx">Cmd+G</strong> <strong class="key win">Ctrl+G</strong> (the same command used to group multiple elements).</p>
 
       <h2>Container Tool (G)</h2>
       <p>Containers are used for grouping elements. However, containers are not like groups in standard image editing software. They have their own dimensions and can be styled like other elements.</p>


### PR DESCRIPTION
The docs recommend converting elements to containers (and they should!), but don't mention how to do it.  Considering that right now containers can get converted into empty elements by moving things around in the outline, knowing how to change them back easily seems like a good idea.
